### PR TITLE
Alternative source of protein domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ the area is exponentially proportional to the count indicated. Examples:
   -dpi=300                set DPI (PNG output only)
 ```
 
+#### Domain sources:
+
+```
+  -D pfam                 set the source of protein domains
+                          pfam:     use Pfam domains only
+                          interpro: use representative domains 
+                                    from CDD, NCBIfam, Pfam, PROSITE, and SMART
+```
+
 ## Installation
 
 Head over to the [Releases](https://github.com/joiningdata/lollipops/releases) to

--- a/data/data.go
+++ b/data/data.go
@@ -60,6 +60,7 @@ type InterProMetaData struct {
 	Accession string `json:"accession"`
 	Name      string `json:"name"`
 	Type      string `json:"type"`
+	Database  string `json:"source_database"`
 }
 
 type InterProExtraField struct {
@@ -67,9 +68,10 @@ type InterProExtraField struct {
 }
 
 type InterProFragment struct {
-	Start      json.Number `json:"start"`
-	End        json.Number `json:"end"`
-	SeqFeature string      `json:"seq_feature"`
+	Start          json.Number `json:"start"`
+	End            json.Number `json:"end"`
+	SeqFeature     string      `json:"seq_feature"`
+	Representative bool        `json:"representative"`
 }
 
 type InterProLocation struct {

--- a/data/interpro.go
+++ b/data/interpro.go
@@ -52,7 +52,11 @@ func GetProteinMatches(database string, accession string) ([]GraphicFeature, err
 	if err != nil {
 		return nil, err
 	}
-	if resp.StatusCode != 200 {
+
+	var gs []GraphicFeature
+	if resp.StatusCode == 204 {
+		return gs, nil
+	} else if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("InterPro error: %s", resp.Status)
 	}
 
@@ -62,7 +66,6 @@ func GetProteinMatches(database string, accession string) ([]GraphicFeature, err
 		return nil, err
 	}
 
-	var gs []GraphicFeature
 	for _, e := range r.Entries {
 		for _, m := range e.Matches {
 			for _, l := range m.Locations {

--- a/data/interpro.go
+++ b/data/interpro.go
@@ -128,7 +128,11 @@ func GetSequenceFeatures(accession string) ([]GraphicFeature, error) {
 	if err != nil {
 		return nil, err
 	}
-	if resp.StatusCode != 200 {
+
+	var gs []GraphicFeature
+	if resp.StatusCode == 204 {
+		return gs, nil
+	} else if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("InterPro error: %s", resp.Status)
 	}
 
@@ -139,7 +143,6 @@ func GetSequenceFeatures(accession string) ([]GraphicFeature, error) {
 		return nil, fmt.Errorf("InterPro error: %s", err)
 	}
 
-	var gs []GraphicFeature
 	featureDatabases := map[string]string{
 		"signalp_e":  "sig_p",
 		"signalp_g+": "sig_p",

--- a/main.go
+++ b/main.go
@@ -180,6 +180,9 @@ Output options:
 
 	if *uniprot != "" {
 		acc = *uniprot
+		if geneSymbol == "" {
+			geneSymbol = acc
+		}
 	}
 
 	if flag.NArg() == 0 && *uniprot == "" {


### PR DESCRIPTION
`lollipop` fetches Pfam domains and additional motif features using the InterPro REST API. If there are no Pfam domains or motif features, the REST API response will return an HTTP status of 204 (No Content). Currently, the code checks that responses have an HTTP status of 200 and exits if they don't. This pull request changes this behavior to accepts 204 HTTP responses (although no regions will be drawn in this case).

**Example for `CCDC61` (no Pfam annotation)**

```sh
./lollipops -legend -show-motifs -show-disordered -w=1400 -o CCDC61.png CCDC61 R21Q Q63T G102A
```

![CCDC61](https://github.com/joiningdata/lollipops/assets/2097501/e8165a98-705b-4346-b226-cdb6cd3d7688)

---

This pull request introduces a new option, `-D <source>`, which enables the customization of the domain source. By default, it is set to _Pfam_ (consistent with the current behavior). However, it also accepts _InterPro_ as a source. In the case of InterPro, representative domains, selected from all domain and repeat databases within the InterPro consortium (including CDD, NCBIfam, Pfam, PROSITE, and SMART), are retrieved and then drawn.

**Example for `CCDC61` (no Pfam annotation, but CDD annotation)**

```sh
./lollipops -legend -show-motifs -show-disordered -D interpro -w=1400 -o CCDC61.png CCDC61 R21Q Q63T G102A
```

![CCDC61](https://github.com/joiningdata/lollipops/assets/2097501/91f0e2d9-816b-466d-be1f-a2a8c6eeb90c)

There are cases where two databases of protein families and domains describe the same domain, but with slightly different annotation locations. The use of `-D interpro` allows for the drawing of the "best" domain, typically the longest one.

Example with `PIK3CA`:

```sh
./lollipops -labels -legend -D pfam -w=1400 -o PIK3CA-Pfam.png PIK3CA N345K
```

![PIK3CA-Pfam](https://github.com/joiningdata/lollipops/assets/2097501/bdaa58bf-b4de-4ffb-8f33-c7d625a36197)

The Pfam PI3K-type C2 domain does not include the N345K variant.

```sh
./lollipops -labels -legend -D interpro -w=1400 -o PIK3CA-InterPro.png PIK3CA N345K
```

![PIK3CA-InterPro](https://github.com/joiningdata/lollipops/assets/2097501/61eaa8b0-c3ea-4f20-8b13-e8aac26929e7)

However, the same domain described by CDD does.

---

Finally, in cases where the `-o <filename>` option is not provided, the graphic is saved as `<gene-symbol>.svg`. However, if a UniProtKB accession is used instead of a gene symbol (`-U <accession>`), the graphic is saved as `.svg`. This pull request resolves this issue by using the UniProt accession for the output file.