### PR TITLE
Fix `-D interpro` option to correctly include domains in the output plot

### DIFF
--- a/data/data.go
+++ b/data/data.go
@@ -68,14 +68,14 @@ type InterProExtraField struct {
 }
 
 type InterProFragment struct {
-	Start          json.Number `json:"start"`
-	End            json.Number `json:"end"`
-	SeqFeature     string      `json:"seq_feature"`
-	Representative bool        `json:"representative"`
+	Start      json.Number `json:"start"`
+	End        json.Number `json:"end"`
+	SeqFeature string      `json:"seq_feature"`
 }
 
 type InterProLocation struct {
-	Fragments []InterProFragment `json:"fragments"`
+	Fragments      []InterProFragment `json:"fragments"`
+	Representative bool               `json:"representative"`
 }
 
 type InterProMatch struct {

--- a/data/interpro.go
+++ b/data/interpro.go
@@ -70,7 +70,7 @@ func GetProteinMatches(database string, accession string) ([]GraphicFeature, err
 		for _, m := range e.Matches {
 			for _, l := range m.Locations {
 				for _, f := range l.Fragments {
-					if !filterDomains || f.Representative {
+					if !filterDomains || l.Representative {
 						gf := GraphicFeature{
 							Text:  e.ExtraFields.ShortName,
 							Type:  e.Metadata.Type,


### PR DESCRIPTION
Hi @pbnjay,

This small PR addresses an issue caused by a recent change in how the representative property is stored in the JSON response when querying InterPro matches for a given UniProtKB accession. The change led to `lollipops` failing to include any domains in the output plot when the `-D interpro` option is used.